### PR TITLE
bump version

### DIFF
--- a/ig.cabal
+++ b/ig.cabal
@@ -1,5 +1,5 @@
 name:                ig
-version:             0.2.1
+version:             0.2.2
 synopsis:            Bindings to Instagram's API.
 homepage:            https://github.com/prowdsponsor/ig
 license:             BSD3


### PR DESCRIPTION
The latest version of ``ig`` in Hackage is older than the most recent commit to hit the Github project. Bump the version in order to request that a new version be uploaded to Hackage :)