### PR TITLE
Support more libraries

### DIFF
--- a/ig.cabal
+++ b/ig.cabal
@@ -1,5 +1,5 @@
 name:                ig
-version:             0.2.1
+version:             0.2.2
 synopsis:            Bindings to Instagram's API.
 homepage:            https://github.com/prowdsponsor/ig
 license:             BSD3

--- a/ig.cabal
+++ b/ig.cabal
@@ -50,7 +50,6 @@ library
     , resourcet
     , http-types
     , http-conduit         >= 2.0     && < 2.2
-    , attoparsec           >= 0.10    && < 0.12
     , aeson                >= 0.5
     , time
     , data-default
@@ -62,7 +61,7 @@ library
     , base16-bytestring    >= 0.1
   if flag(conduit11)
     build-depends:
-        conduit              == 1.1.*
+        conduit              >= 1.1.0.0 && < 1.3
       , conduit-extra        == 1.1.*
   else
     build-depends:


### PR DESCRIPTION
``ig`` has somewhat strict constraints on what it will compile against. In particular:

- ``attoparsec``, which is not a direct dependency of ``ig``, has to be less than 0.12.
- ``conduit`` can be either ``1.0`` series or ``1.1`` series. It seems from the changelog at https://github.com/snoyberg/conduit/commit/e03ee0e24212f358dfa376283125618e725c0156 that no breaking changes are expected unless you import ``.Internal``.
- ``monad-control`` > 1.0 breaks everything.

This branch loosens those constraints by deleting the direct dependency on ``attoparsec`` (leaving our direct dependencies to deal with it), widening the constraint on ``conduit`` in the 1.1 series case, and adding support for the new ``monad-control``. This is based on https://github.com/kazu-yamamoto/ghc-mod/pull/423/ and https://hackage.haskell.org/package/monad-control-0.3.3.1/docs/Control-Monad-Trans-Control.html#g:2, and they seem to compile, although I can't claim that I understand them thoroughly enough to promise that they work.