### PR TITLE
Add bio and counts to User

### DIFF
--- a/src/Instagram.hs
+++ b/src/Instagram.hs
@@ -15,6 +15,7 @@ module Instagram
   ,OAuthToken(..)
   ,AccessToken(..) -- we open this type so that the api client can just use the token data outside of your type (as a simple Text)
   ,User(..)
+  ,UserCounts(..)
   ,Scope(..)
   
   -- data

--- a/src/Instagram/Types.hs
+++ b/src/Instagram/Types.hs
@@ -8,6 +8,7 @@ module Instagram.Types (
   ,AccessToken(..)
   ,UserID
   ,User(..)
+  ,UserCounts(..)
   ,Scope(..)
   ,IGException(..)
   ,Envelope(..)
@@ -109,13 +110,22 @@ data User = User {
         uUsername :: Text,
         uFullName :: Text,
         uProfilePicture :: Maybe Text,
-        uWebsite :: Maybe Text
-        }        
+        uWebsite :: Maybe Text,
+        uBio :: Maybe Text,
+        uCounts :: Maybe UserCounts
+        }
         deriving (Show,Read,Eq,Ord,Typeable)
     
 -- | to json as per Instagram format    
 instance ToJSON User  where
-    toJSON u=object ["id" .= uID u, "username" .= uUsername u , "full_name" .= uFullName u, "profile_picture" .= uProfilePicture u, "website" .= uWebsite u] 
+    toJSON u = object
+        [ "id" .= uID u
+        , "username" .= uUsername u
+        , "full_name" .= uFullName u
+        , "profile_picture" .= uProfilePicture u
+        , "website" .= uWebsite u
+        , "bio" .= uBio u
+        ]
 
 -- | from json as per Instagram format
 instance FromJSON User where
@@ -124,9 +134,35 @@ instance FromJSON User where
                          v .: "username" <*>
                          v .: "full_name" <*>
                          v .:? "profile_picture" <*>
-                         v .:? "website"
+                         v .:? "website" <*>
+                         v .:? "bio" <*>
+                         v .:? "counts"
     parseJSON _= fail "User"
-    
+
+-- | the User counts info returned by some endpoints
+data UserCounts = UserCounts
+    { ucMedia :: Int
+    , ucFollows :: Int
+    , ucFollowedBy :: Int
+    }
+    deriving (Show,Read,Eq,Ord,Typeable)
+
+-- | from json as per Instagram format
+instance FromJSON UserCounts where
+    parseJSON (Object v) = UserCounts <$>
+                         v .: "media" <*>
+                         v .: "follows" <*>
+                         v .: "followed_by"
+    parseJSON _= fail "UserCounts"
+
+-- | to json as per Instagram format
+instance ToJSON UserCounts where
+    toJSON uc = object
+        [ "media" .= ucMedia uc
+        , "follows" .= ucFollows uc
+        , "followed_by" .= ucFollowedBy uc
+        ]
+
 -- | the scopes of the authentication
 data Scope=Basic | Comments | Relationships | Likes
         deriving (Show,Read,Eq,Ord,Enum,Bounded,Typeable)


### PR DESCRIPTION
Hello,

Users endpoint (https://instagram.com/developer/endpoints/users) returns following response:

```
{
    "data": {
        "id": "1574083",
        "username": "snoopdogg",
        "full_name": "Snoop Dogg",
        "profile_picture": "http://distillery.s3.amazonaws.com/profiles/profile_1574083_75sq_1295469061.jpg",
        "bio": "This is my bio",
        "website": "http://snoopdogg.com",
        "counts": {
            "media": 1320,
            "follows": 420,
            "followed_by": 3410
        }
}
```

This PR changes User to include bio and counts.

What do you think?