### PR TITLE
Fix JSON exception

### DIFF
--- a/ig.cabal
+++ b/ig.cabal
@@ -1,5 +1,5 @@
 name:                ig
-version:             0.3.1
+version:             0.4
 synopsis:            Bindings to Instagram's API.
 homepage:            https://github.com/prowdsponsor/ig
 license:             BSD3

--- a/src/Instagram/Relationships.hs
+++ b/src/Instagram/Relationships.hs
@@ -87,5 +87,5 @@ instance HT.QueryLike RelationShipAction where
 setRelationShip :: (MonadBaseControl IO m, MonadResource m) => UserID
   -> OAuthToken
   -> RelationShipAction
-  -> InstagramT m (Envelope Relationship)
+  -> InstagramT m (Envelope (Maybe Relationship))
 setRelationShip uid=getPostEnvelope ["/v1/users/",uid,"/relationship"]


### PR DESCRIPTION
There is a corner case where, if a user tries to set a relationship using their own id, Instagram API returns a successful response that doesn't include any data, leading to a `JSONException`.

Running these instructions in a `cabal repl`:

```haskell
:set -XOverloadedStrings
:m +Network.HTTP.Conduit
:m +Control.Monad.Trans.Resource
let creds = Credentials "" ""
let userId = "XXX"
let selfId = "YYY"
let user = User "" "" "" Nothing Nothing Nothing Nothing
let oAuthToken = OAuthToken (AccessToken "ZZZ") user
let setSelfRelationShipAction = setRelationShip selfId oAuthToken Follow
manager <- newManager tlsManagerSettings
```

the expression

```haskell
runResourceT $ runInstagramT creds manager setRelationShipAction
```

returned

    *** Exception: JSONException "Relationship"

With this fix the same expression now returns

    Envelope {eMeta = IGError {igeCode = 200, igeType = Nothing, igeMessage = Nothing}, eData = Nothing, ePagination = Nothing}

See also https://instagram.com/developer/endpoints/relationships/#post_relationship