### PR TITLE
make `getRecent` not require an `OAuthToken`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cabal-dev
 *~
 /.dist-buildwrapper
 /.project
+.stack-work/

--- a/ig.cabal
+++ b/ig.cabal
@@ -1,5 +1,5 @@
 name:                ig
-version:             0.4
+version:             0.5
 synopsis:            Bindings to Instagram's API.
 homepage:            https://github.com/prowdsponsor/ig
 license:             BSD3

--- a/src/Instagram/Users.hs
+++ b/src/Instagram/Users.hs
@@ -2,15 +2,15 @@
 -- | Users end point handling
 -- <http://instagram.com/developer/endpoints/users/#>
 module Instagram.Users (
-  getUser
-  ,SelfFeedParams(..)
-  ,getSelfFeed
-  ,RecentParams(..)
-  ,getRecent
-  ,SelfLikedParams(..)
-  ,getSelfLiked
-  ,UserSearchParams(..)
-  ,searchUsers
+    getUser
+  , SelfFeedParams(..)
+  , getSelfFeed
+  , RecentParams(..)
+  , getRecent
+  , SelfLikedParams(..)
+  , getSelfLiked
+  , UserSearchParams(..)
+  , searchUsers
 ) where
 
 import Instagram.Monad
@@ -27,10 +27,11 @@ import Data.Default
 
 
 -- | Get basic information about a user.
-getUser ::     (MonadBaseControl IO m, MonadResource m) => UserID
-  -> Maybe OAuthToken
-  -> InstagramT m (Envelope (Maybe User))
-getUser uid token  =getGetEnvelopeM ["/v1/users/",uid] token ([]::HT.Query)
+getUser :: (MonadBaseControl IO m, MonadResource m)
+        => UserID
+        -> Maybe OAuthToken
+        -> InstagramT m (Envelope (Maybe User))
+getUser uid token = getGetEnvelopeM ["/v1/users/",uid] token ([]::HT.Query)
 
 -- | Parameters for call to self feed
 data SelfFeedParams = SelfFeedParams {
@@ -41,21 +42,22 @@ data SelfFeedParams = SelfFeedParams {
   deriving (Show,Typeable)
 
 instance Default SelfFeedParams where
-  def=SelfFeedParams Nothing Nothing Nothing
+  def = SelfFeedParams Nothing Nothing Nothing
 
 instance HT.QueryLike SelfFeedParams where
-  toQuery (SelfFeedParams c maxI minI)=filter (isJust .snd)
-    ["count" ?+ c
-    ,"max_id" ?+ maxI
-    ,"min_id" ?+ minI]
+  toQuery (SelfFeedParams c maxI minI) = filter (isJust .snd)
+    [ "count" ?+ c
+    , "max_id" ?+ maxI
+    , "min_id" ?+ minI
+    ]
 
 
 -- |  See the authenticated user's feed.
-getSelfFeed :: (MonadBaseControl IO m, MonadResource m) =>
-  OAuthToken
-  -> SelfFeedParams
-  -> InstagramT m (Envelope [Media])
-getSelfFeed =getGetEnvelope ["/v1/users/self/feed/"]
+getSelfFeed :: (MonadBaseControl IO m, MonadResource m)
+            => OAuthToken
+            -> SelfFeedParams
+            -> InstagramT m (Envelope [Media])
+getSelfFeed = getGetEnvelope ["/v1/users/self/feed/"]
 
 -- | Parameters for call to recent media
 data RecentParams = RecentParams {
@@ -68,59 +70,65 @@ data RecentParams = RecentParams {
   deriving (Show,Typeable)
 
 instance Default RecentParams where
-  def=RecentParams Nothing Nothing Nothing Nothing Nothing
+  def = RecentParams Nothing Nothing Nothing Nothing Nothing
 
 instance HT.QueryLike RecentParams where
-  toQuery (RecentParams c maxT minT maxI minI)=filter (isJust .snd)
-    ["count" ?+ c
-    ,"max_timestamp" ?+ maxT
-    ,"min_timestamp" ?+ minT
-    ,"max_id" ?+ maxI
-    ,"min_id" ?+ minI]
+  toQuery (RecentParams c maxT minT maxI minI) = filter (isJust .snd)
+    [ "count" ?+ c
+    , "max_timestamp" ?+ maxT
+    , "min_timestamp" ?+ minT
+    , "max_id" ?+ maxI
+    , "min_id" ?+ minI
+    ]
 
 
 -- | Get the most recent media published by a user.
-getRecent :: (MonadBaseControl IO m, MonadResource m) => UserID
-  -> OAuthToken
-  -> RecentParams
-  -> InstagramT m (Envelope [Media])
-getRecent uid=getGetEnvelope ["/v1/users/",uid,"/media/recent/"]
+getRecent :: (MonadBaseControl IO m, MonadResource m)
+          => UserID
+          -> OAuthToken
+          -> RecentParams
+          -> InstagramT m (Envelope [Media])
+getRecent uid = getGetEnvelope ["/v1/users/",uid,"/media/recent/"]
 
 -- | parameters for self liked call
 data SelfLikedParams = SelfLikedParams {
-  slpCount :: Maybe Integer,
-  slpMaxLikeID :: Maybe T.Text
+    slpCount :: Maybe Integer,
+    slpMaxLikeID :: Maybe T.Text
   }
   deriving (Show,Typeable)
 
 instance Default SelfLikedParams where
-  def=SelfLikedParams Nothing Nothing
+  def = SelfLikedParams Nothing Nothing
 
 instance HT.QueryLike SelfLikedParams where
-  toQuery (SelfLikedParams c maxI)=filter (isJust .snd)
-    ["count" ?+ c
-    ,"max_like_id" ?+ maxI]
+  toQuery (SelfLikedParams c maxI) = filter (isJust .snd)
+    [ "count" ?+ c
+    , "max_like_id" ?+ maxI
+    ]
 
 -- | See the authenticated user's list of media they've liked.
-getSelfLiked :: (MonadBaseControl IO m, MonadResource m) => OAuthToken
-  -> SelfLikedParams
-  -> InstagramT m (Envelope [Media])
-getSelfLiked =getGetEnvelope ["/v1/users/self/media/liked"]
+getSelfLiked :: (MonadBaseControl IO m, MonadResource m)
+             => OAuthToken
+             -> SelfLikedParams
+             -> InstagramT m (Envelope [Media])
+getSelfLiked = getGetEnvelope ["/v1/users/self/media/liked"]
 
 -- | parameters for self liked call
 data UserSearchParams = UserSearchParams {
-  uspQuery :: T.Text,
-  uspCount :: Maybe Integer
+    uspQuery :: T.Text,
+    uspCount :: Maybe Integer
   }
   deriving (Show,Typeable)
 
 instance HT.QueryLike UserSearchParams where
-  toQuery (UserSearchParams q c )=filter (isJust .snd)
-    ["count" ?+ c -- does not seem to be taken into account...
-    ,"q" ?+ q]
+  toQuery (UserSearchParams q c ) = filter (isJust .snd)
+    [ "count" ?+ c -- does not seem to be taken into account...
+    , "q" ?+ q
+    ]
 
 -- | Search for a user by name.
-searchUsers :: (MonadBaseControl IO m, MonadResource m) => Maybe OAuthToken
-  -> UserSearchParams
-  -> InstagramT m (Envelope [User])
-searchUsers =getGetEnvelopeM ["/v1/users/search"]
+searchUsers :: (MonadBaseControl IO m, MonadResource m)
+            => Maybe OAuthToken
+            -> UserSearchParams
+            -> InstagramT m (Envelope [User])
+searchUsers = getGetEnvelopeM ["/v1/users/search"]

--- a/src/Instagram/Users.hs
+++ b/src/Instagram/Users.hs
@@ -85,10 +85,10 @@ instance HT.QueryLike RecentParams where
 -- | Get the most recent media published by a user.
 getRecent :: (MonadBaseControl IO m, MonadResource m)
           => UserID
-          -> OAuthToken
+          -> Maybe OAuthToken
           -> RecentParams
           -> InstagramT m (Envelope [Media])
-getRecent uid = getGetEnvelope ["/v1/users/",uid,"/media/recent/"]
+getRecent uid = getGetEnvelopeM ["/v1/users/",uid,"/media/recent/"]
 
 -- | parameters for self liked call
 data SelfLikedParams = SelfLikedParams {

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,8 @@
+flags:
+  ig:
+    debug: false
+    conduit11: true
+packages:
+- '.'
+extra-deps: []
+resolver: lts-3.2


### PR DESCRIPTION
This pull request fixes the following things:

- Added a `stack.yaml` file to make it easier for `stack` users to build this repository.
- Formatted Users.hs to make the code more uniform.
- Changed `Instagram.Users.getRecent` to not require an `OAuthToken`.
- Bumped version to 0.5.

This fixes issue #15.