### PR TITLE
Removing attoparsec dependency.

### DIFF
--- a/ig.cabal
+++ b/ig.cabal
@@ -50,7 +50,6 @@ library
     , resourcet
     , http-types
     , http-conduit         >= 2.0     && < 2.2
-    , attoparsec           >= 0.10    && < 0.13
     , aeson                >= 0.5
     , time
     , data-default


### PR DESCRIPTION
It looks like an attoparsec depencency was added that is not actually needed by pull request #20.  This removes that dependency.

It looks like there was a problem with stackage by the `< 0.13` attoparsec dependency: https://github.com/fpco/stackage/issues/875