### PR TITLE
Add support for new scopes

### DIFF
--- a/src/Instagram/Auth.hs
+++ b/src/Instagram/Auth.hs
@@ -35,7 +35,7 @@ getUserAccessTokenURL1 url scopes=  do
     buildQuery cid=[("client_id",cid),("redirect_uri",TE.encodeUtf8 url),("response_type","code")]
     buildScopes ::  [Scope] ->  HT.SimpleQuery
     buildScopes []=[]
-    buildScopes l =[("scope",BS.intercalate "+" $ map (TE.encodeUtf8 . toLower . pack . show) l)]
+    buildScopes l =[("scope",BS.intercalate "+" $ map (TE.encodeUtf8 . pack . show) l)]
 
 -- | second step of authorization: get the access token once the user has been redirected with a code
 getUserAccessTokenURL2 :: (MonadBaseControl IO m, MonadResource m) =>

--- a/src/Instagram/Types.hs
+++ b/src/Instagram/Types.hs
@@ -166,8 +166,16 @@ instance ToJSON UserCounts where
         ]
 
 -- | the scopes of the authentication
-data Scope=Basic | Comments | Relationships | Likes
-        deriving (Show,Read,Eq,Ord,Enum,Bounded,Typeable)
+data Scope = Basic | PublicContent | FollowerList | Comments | Relationships | Likes
+  deriving (Read,Eq,Ord,Enum,Bounded,Typeable)
+
+instance Show Scope where
+  show Basic         = "basic"
+  show PublicContent = "public_content"
+  show FollowerList  = "follower_list"
+  show Comments      = "comments"
+  show Relationships = "relationships"
+  show Likes         = "likes"
 
 -- | an error returned to us by Instagram
 data IGError = IGError {


### PR DESCRIPTION
Addresses #22 

:package:
  - Extended `Scope` constructor to include `public_content` and `follower_list`
    scopes
  - Defined a `Show` instance
  - Removed `toLower` from `buildScopes` composition (delegated to `show`) in `getUserAccessTokenURL1`

*Stack repl:*
```haskell
>> let l = [Basic, Relationships, FollowerList, PublicContent, Comments, Likes]
>> [("scope",BS.intercalate "+" $ map (TE.encodeUtf8 . pack . show) l)]
[("scope","basic+relationships+follower_list+public_content+comments+likes")]
```

> According to the [API Docs | Authorization](https://www.instagram.com/developer/authorization/):
  - basic - to read a user’s profile info and media (granted by default)
  - public_content - to read any public profile info and media on a user’s behalf
  - follower_list - to read the list of followers and followed-by users
  - comments - to post and delete comments on a user’s behalf
  - relationships - to follow and unfollow accounts on a user’s behalf
  - likes - to like and unlike media on a user’s behalf
