### PR TITLE
Fix debug compilation when using >= conduit-1.1.*

### DIFF
--- a/ig.cabal
+++ b/ig.cabal
@@ -94,3 +94,6 @@ library
                   Instagram.Geographies
   if flag(debug)
     cpp-options: -DDEBUG
+
+  if flag(conduit11)
+    cpp-options: -DCONDUIT11

--- a/src/Instagram/Monad.hs
+++ b/src/Instagram/Monad.hs
@@ -69,7 +69,11 @@ import Data.Time.Clock.POSIX (POSIXTime)
 import Control.Monad.IO.Class (liftIO)
 import Data.Conduit.Binary (sinkHandle)
 import System.IO (stdout)
+#if CONDUIT11
+import Data.Conduit (ZipSink(ZipSink, getZipSink))
+#else
 import Data.Conduit.Util (zipSinks)
+#endif
 #endif
 
 -- | the instagram monad transformer
@@ -190,9 +194,17 @@ igReq req extractError=do
       err=H.StatusCodeException status headers cookies
   L.catch (do
 #if DEBUG
+#if CONDUIT11
+    -- DEBUG and CONDUIT11
+    (value,_)<-H.responseBody res C.$$+- getZipSink $ (,) <$>
+      ZipSink (sinkParser json) <*> ZipSink (sinkHandle stdout)
+#else
+    -- DEBUG and not CONDUIT11
     (value,_)<-H.responseBody res C.$$+- zipSinks (sinkParser json) (sinkHandle stdout)
+#endif
     liftIO $ BSC.putStrLn ""
 #else
+    -- not DEBUG
     value<-H.responseBody res C.$$+- sinkParser json
 #endif
     if ok

--- a/src/Instagram/Monad.hs
+++ b/src/Instagram/Monad.hs
@@ -196,7 +196,7 @@ igReq req extractError=do
 #if DEBUG
 #if CONDUIT11
     -- DEBUG and CONDUIT11
-    (value,_)<-H.responseBody res C.$$+- getZipSink $ (,) <$>
+    value<-H.responseBody res C.$$+- getZipSink $ const <$>
       ZipSink (sinkParser json) <*> ZipSink (sinkHandle stdout)
 #else
     -- DEBUG and not CONDUIT11


### PR DESCRIPTION
Makes `ig` in debug mode compatible with both new and old versions of `conduit`.
