### PR TITLE
Add content-type header to form POSTs.

### DIFF
--- a/src/Instagram/Monad.hs
+++ b/src/Instagram/Monad.hs
@@ -139,6 +139,7 @@ getPostRequest path query=do
                      , H.path = path
                      , H.method=HT.methodPost
                      , H.requestBody=H.RequestBodyBS $ HT.renderQuery False $ HT.toQuery query
+                     , H.requestHeaders=[("Content-Type","application/x-www-form-urlencoded")]
                 }
 
 -- | build a get request to Instagram


### PR DESCRIPTION
Instagram OAUTH was failing without this.
